### PR TITLE
fix: Write .env output to src directory root for subsequent tasks

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ params:
 
 ### get-app-env
 
-It gets the env vars for a CF application and writes them to a `.env` file for consumption in the following task.
+It gets the env vars for a CF application and writes them to a `.env` file for consumption in the following task. This task expects the pipeline's source code to be aliased to `src` and will output the file to the root of the source code located at `$PWD/src/.env`.
 
 - Required params: `APP_ENV`, `CF_APP_NAME`, `$CF_ORG`, `$CF_SPACE`, `$CF_API`, `CF_USERNAME`, `CF_PASSWORD`
 - Required image: `general-task`

--- a/scripts/get-app-env.sh
+++ b/scripts/get-app-env.sh
@@ -11,4 +11,4 @@ CF_APP_GUID=`cf app $CF_APP_NAME --guid`
 
 cf curl /v3/apps/$CF_APP_GUID/env | \
     jq -r 'to_entries | .[] | .value | to_entries | map({key, value: (.value | tostring) }) | .[] | join("=")' \
-    > .env
+    > $PWD/src/.env

--- a/tasks/get-app-env.yml
+++ b/tasks/get-app-env.yml
@@ -1,5 +1,6 @@
 platform: linux
 inputs:
   - name: pipeline-tasks
+  - name: src
 run:
   path: pipeline-tasks/scripts/get-app-env.sh


### PR DESCRIPTION
## Changes proposed in this pull request:

- Fix get-app-env task to write the .env output to the pipeline's src root directory
- Expects source code to be set to alias `src`

## Security considerations
None
