### PR TITLE
feat: Add npm audit and run bash command tasks

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ It gets the env vars for a CF application and writes them to a `.env` file for c
 ```yml
 task: get-app-env
 image: general-task
+file: pipeline-tasks/tasks/get-app-env.yml
 params:
   _: #@ template.replace(data.values.env_cf)
   APP_ENV: ((deploy-env))
@@ -66,6 +67,27 @@ params:
     PIPELINE_YML: src/ci/pipeline.yml
 ```
 
+### npm-audit
+
+Runs npm audit and defaults to fail task if there are any `high` findings or above.
+- Optional params: `NPM_AUDIT_LEVEL` defaults to `high`.
+  - Available options: `info`, `low`, `moderate`, `high`, `critical`, `none`
+- Required Image: `node`
+
+```yml
+task: audit-dependencies
+image: node
+file: pipeline-tasks/partials/npm-audit.yml
+
+// OR
+
+task: audit-dependencies
+image: node
+file: pipeline-tasks/partials/npm-audit.yml
+params:
+    NPM_AUDIT_LEVEL: moderate
+```
+
 ### restage
 
 Restage a cf application.
@@ -81,6 +103,27 @@ params:
     CF_ORG: org
     CF_SPACE: space
     CF_APP_NAME: app
+```
+
+### run-command
+
+Runs the provided bash command from the `src` directory
+- Required params: `COMMAND`
+
+```yml
+task: the-script
+image: node
+file: pipeline-tasks/partials/run-command.yml
+params:
+    COMMAND: npm run the-script
+
+// OR
+
+task: cat-file
+image: general-task
+file: pipeline-tasks/partials/run-command.yml
+params:
+    COMMAND: cat some_file.txt
 ```
 
 ### boot

--- a/scripts/get-app-env.sh
+++ b/scripts/get-app-env.sh
@@ -11,4 +11,4 @@ CF_APP_GUID=`cf app $CF_APP_NAME --guid`
 
 cf curl /v3/apps/$CF_APP_GUID/env | \
     jq -r 'to_entries | .[] | .value | to_entries | map({key, value: (.value | tostring) }) | .[] | join("=")' \
-    > $PWD/src/.env
+    > .env

--- a/tasks/npm-audit.yml
+++ b/tasks/npm-audit.yml
@@ -1,0 +1,8 @@
+platform: linux
+inputs:
+  - name: pipeline-tasks
+  - name: src
+run:
+  dir: src
+  path: bash
+  args: [-c, "npm audit --audit-level ${NPM_AUDIT_LEVEL:-'high'}"]

--- a/tasks/run-command.yml
+++ b/tasks/run-command.yml
@@ -4,4 +4,5 @@ inputs:
   - name: src
 run:
   dir: src
-  path: pipeline-tasks/scripts/get-app-env.sh
+  path: bash
+  args: [-c, "$COMMAND"]


### PR DESCRIPTION
## Changes proposed in this pull request:

- Adds an npm-audit task to run audit on dependencies
- Adds a run-command task to run general bash command.
- Clean ups get-app-env task

## Security considerations

None
