### PR TITLE
fix: Set get-app-env to proper path and output src

### DIFF
--- a/tasks/get-app-env.yml
+++ b/tasks/get-app-env.yml
@@ -2,6 +2,8 @@ platform: linux
 inputs:
   - name: pipeline-tasks
   - name: src
+outputs:
+  - name: src
 run:
   dir: src
-  path: pipeline-tasks/scripts/get-app-env.sh
+  path: ../pipeline-tasks/scripts/get-app-env.sh


### PR DESCRIPTION
## Changes proposed in this pull request:

-  Set the proper path to execute script
- Add output src in task config so following tasks can use the .env

## Security considerations
None