### PR TITLE
don't perform implicit get when setting pr status

### DIFF
--- a/common/funcs.lib.yml
+++ b/common/funcs.lib.yml
@@ -34,4 +34,5 @@ params:
   status: #@ state
   base_context: concourse
   context: #@ name
+no_get: true
 #@ end


### PR DESCRIPTION
## Changes proposed in this pull request:
- don't perform implicit `get` when setting pr status
- [`no-get`](https://concourse-ci.org/put-step.html#schema.put.no_get)
- It often isn't necessary to perform an implicit `get` and in our pipelines, doing so can create errors. When PR resources use `integration_tool: checkout` in the `get` step, that parameter isn't replicated in the implicit `get` and if there are merge conflicts in the PR, the pipeline will fail. For this specific case we could use [`get_params`](https://concourse-ci.org/put-step.html#schema.put.get_params) but it's hard to abstract that pattern if this hook is used elsewhere

## Security considerations
None