### PR TITLE
chore: rename editor space variables again

### DIFF
--- a/common/values.yml
+++ b/common/values.yml
@@ -5,7 +5,7 @@ env_cf: ((((deploy-env))-cf-username))
 env_cf_build_tasks: ((build-tasks-((deploy-env))-cf-username))
 env_cf_redirects: ((redirects-cf-username))
 env_cf_email: ((email-cf-username))
-env_cf_editor: ((payload-cf-username))
+env_cf_editor: ((editor-cf-username))
 #@ end
 
 #@ def passwords():
@@ -13,7 +13,7 @@ env_cf: ((((deploy-env))-cf-password))
 env_cf_build_tasks: ((build-tasks-((deploy-env))-cf-password))
 env_cf_redirects: ((redirects-cf-password))
 env_cf_email: ((email-cf-password))
-env_cf_editor: ((payload-cf-password))
+env_cf_editor: ((editor-cf-password))
 #@ end
 
 #@ def spaces():
@@ -21,7 +21,7 @@ env_cf: ((deploy-env))
 env_cf_build_tasks: build-tasks-((deploy-env))
 env_cf_redirects: redirects
 env_cf_email: email
-env_cf_editor: payload-test
+env_cf_editor: editor
 #@ end
 
 

--- a/common/values.yml
+++ b/common/values.yml
@@ -21,7 +21,7 @@ env_cf: ((deploy-env))
 env_cf_build_tasks: build-tasks-((deploy-env))
 env_cf_redirects: redirects
 env_cf_email: email
-env_cf_editor: editor
+env_cf_editor: editor-((deploy-env))
 #@ end
 
 


### PR DESCRIPTION
## Changes proposed in this pull request:
- #18 but hopefully correct this time
- add deploy-env to space

## Security considerations
None