### PR TITLE
Add permissions to github workflow file

### DIFF
--- a/.github/workflows/security-considerations.yml
+++ b/.github/workflows/security-considerations.yml
@@ -1,5 +1,8 @@
 name: Security Considerations Workflow
 
+permissions:
+  contents: read
+
 on:
   pull_request:
     types: [opened, edited, reopened]


### PR DESCRIPTION
## Changes proposed in this pull request:

GitHub workflow yaml file should have read permissions. If a GitHub Actions job or workflow has no explicit permissions set, then the repository permissions are used. Repositories created under organizations inherit the organization permissions. The organizations or repositories created before February 2023 have the default permissions set to read-write. Often these permissions do not adhere to the principle of least privilege and can be reduced to read-only, leaving the write permission only to a specific types as issues: write or pull-requests: write.

To fix the issue, we will add a permissions block to the workflow. Since the workflow uses the cloud-gov/security-considerations-action@main action, we will assume it only requires read access to repository contents unless the action documentation specifies otherwise. The permissions block will be added at the workflow level to apply to all jobs, ensuring minimal permissions are granted.

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

None